### PR TITLE
Fix: Resolve crash in unknown

### DIFF
--- a/app/failing-app.yaml
+++ b/app/failing-app.yaml
@@ -6,4 +6,4 @@ spec:
   containers:
   - name: crash
     image: busybox
-    command: ["/bin/sh", "-c", "echo Crashing... && exit 1"]
+    command: ["/bin/sh", "-c", "echo Healthy! && sleep 3600"]


### PR DESCRIPTION
This PR auto-fixes the failing pod `unknown` by correcting the container command.