### PR TITLE
Fix: Resolve crash in failing-app-8686489994-8wvsp

### DIFF
--- a/app/failing-app.yaml
+++ b/app/failing-app.yaml
@@ -14,6 +14,9 @@ spec:
         app: failing-app
     spec:
       containers:
-        - name: crash
-          image: busybox
-          command: ["/bin/sh", "-c", "echo Crashing... && exit 1"]
+      - name: crash
+        image: busybox
+        command:
+        - /bin/sh
+        - -c
+        - echo Healthy! && sleep 3600


### PR DESCRIPTION
This PR auto-fixes the failing pod `failing-app-8686489994-8wvsp` by correcting the container command.